### PR TITLE
Prevent sending display entities to client versions that don't support them

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,16 @@ repositories {
     maven {
         url = 'https://repo.extendedclip.com/content/repositories/placeholderapi/'
     }
+    maven {
+        url = 'https://repo.viaversion.com'
+    }
 }
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.6")
     compileOnly("com.mojang:brigadier:1.0.18")
+    compileOnly("com.viaversion:viaversion-api:5.0.5")
 }
 
 def targetJavaVersion = 17

--- a/src/main/java/me/yirf/judge/events/OnSneak.java
+++ b/src/main/java/me/yirf/judge/events/OnSneak.java
@@ -1,5 +1,6 @@
 package me.yirf.judge.events;
 
+import com.viaversion.viaversion.api.Via;
 import me.yirf.judge.Judge;
 import me.yirf.judge.config.Config;
 import me.yirf.judge.group.Group;
@@ -25,6 +26,13 @@ public class OnSneak implements Listener {
 
         if(!Config.getBoolean("allow-all-worlds")) {
             if (!Judge.allowedWorlds.contains(p.getWorld())) {
+                return;
+            }
+        }
+
+        //Prevent displaying to the player if they are on a version without display entities (under 1.19.4) if ViaVersion is installed.
+        if(Bukkit.getServer().getPluginManager().isPluginEnabled("ViaVersion")) {
+            if(Via.getAPI().getPlayerVersion(p.getUniqueId()) < 762) {
                 return;
             }
         }

--- a/src/main/java/me/yirf/judge/events/OnSneakDelay.java
+++ b/src/main/java/me/yirf/judge/events/OnSneakDelay.java
@@ -1,5 +1,6 @@
 package me.yirf.judge.events;
 
+import com.viaversion.viaversion.api.Via;
 import me.yirf.judge.Judge;
 import me.yirf.judge.config.Config;
 import me.yirf.judge.group.Group;
@@ -29,6 +30,13 @@ public class OnSneakDelay implements Listener {
 
         if(!Config.getBoolean("allow-all-worlds")) {
             if (!Judge.allowedWorlds.contains(p.getWorld())) {
+                return;
+            }
+        }
+
+        //Prevent displaying to the player if they are on a version without display entities (under 1.19.4) if ViaVersion is installed.
+        if(Bukkit.getServer().getPluginManager().isPluginEnabled("ViaVersion")) {
+            if(Via.getAPI().getPlayerVersion(p.getUniqueId()) < 762) {
                 return;
             }
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,9 @@ dependencies:
     WorldGuard:
       load: BEFORE
       required: false
+    ViaVersion:
+      load: BEFORE
+      required: false
 
 commands:
   reloadjudge:


### PR DESCRIPTION
ViaVersion does not properly handle display entities on clients before 1.19.4. While text is displayed, it just gets displayed as one long String instead of multiple lines. To solve this, this PR simply ignores players who are on unsupported versions if ViaVersion is installed.