### PR TITLE
Allow the display to be seen through blocks/entities via the SeeThrough value.

### DIFF
--- a/src/main/java/me/yirf/judge/menu/Display.java
+++ b/src/main/java/me/yirf/judge/menu/Display.java
@@ -22,7 +22,8 @@ public class Display implements Color {
     public static void spawnMenu(Player player, Player target) {
         if(Bukkit.getServer().getPluginManager().isPluginEnabled("ViaVersion")) {
             if(Via.getAPI().getPlayerVersion(player.getUniqueId()) < 762) {
-                Bukkit.broadcastMessage("Less then version!");
+                getLogger().info("Player " + player.getName() + " is on a unsupported version!");
+                player.sendMessage("You are on a unsupported version, some features may not be supported.");
                 return;
             }
         }

--- a/src/main/java/me/yirf/judge/menu/Display.java
+++ b/src/main/java/me/yirf/judge/menu/Display.java
@@ -30,6 +30,7 @@ public class Display implements Color {
         display.setShadowed(true);
         display.setBillboard(Billboard.CENTER);
         display.setVisibleByDefault(true);
+        display.setSeeThrough(true);
         if(!Config.getString("properties.color").equals("DEFAULT")) {
             display.setBackgroundColor(Config.getRGB("properties.color"));
         }


### PR DESCRIPTION
This pull request aims to allow the display to be seen through blocks when viewing it. This is more of a QoL thing that was annoying me while testing Judge on my server. 

p.s this also makes it so it doesn't broadcast when joining on an older version (logs it & tells the player instead)

very very smol pr