### PR TITLE
feat: implements proper vanish support & base cleanup

### DIFF
--- a/src/main/java/me/yirf/judge/events/OnSneak.java
+++ b/src/main/java/me/yirf/judge/events/OnSneak.java
@@ -14,39 +14,55 @@ import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.util.RayTraceResult;
 import static me.yirf.judge.group.Group.group;
 
-public class OnSneak implements Listener {
-    @EventHandler
-    public void onShift(PlayerToggleSneakEvent event) {
-        Player p = event.getPlayer();
+@EventHandler
+public void onShift(PlayerToggleSneakEvent event) {
+    Player p = event.getPlayer();
 
-        if (group.get(p.getUniqueId()) != null) {
-            Group.remove(p);
-            return;
-        }
-
-        if(!Config.getBoolean("allow-all-worlds")) {
-            if (!Judge.allowedWorlds.contains(p.getWorld())) {
-                return;
-            }
-        }
-        if (Judge.hasWorldGuard && Config.getBoolean("specific-regions")) {
-            if (!RegionUtil.containsRegion
-                    (p, Config.getStringList("allowed-regions")
-                    )) return;
-        }
-
-        RayTraceResult result = p.rayTraceEntities(10);if (result == null || !(result.getHitEntity() instanceof Player)) {return;}
-        Entity entity = result.getHitEntity();
-
-        if (entity.hasMetadata("NPC")) {
-            return;
-        }
-
-        if (!event.isSneaking()) {return;}
-        if(Bukkit.getServer().getOnlinePlayers().contains(p)) {
-            Display.spawnMenu(p, (Player) entity);
-        }
-
+    // If the player is already in a group, remove them
+    if (group.get(p.getUniqueId()) != null) {
+        Group.remove(p);
+        return;
     }
 
+    // World restriction check
+    if (!Config.getBoolean("allow-all-worlds")) {
+        if (!Judge.allowedWorlds.contains(p.getWorld())) {
+            return;
+        }
+    }
+
+    // WorldGuard region check
+    if (Judge.hasWorldGuard && Config.getBoolean("specific-regions")) {
+        if (!RegionUtil.containsRegion(p, Config.getStringList("allowed-regions"))) {
+            return;
+        }
+    }
+
+    // Ray trace for nearby player
+    RayTraceResult result = p.rayTraceEntities(10);
+    if (result == null || !(result.getHitEntity() instanceof Player)) {
+        return;
+    }
+
+    Player target = (Player) result.getHitEntity();
+
+    // Check if target is an NPC
+    if (target.hasMetadata("NPC")) {
+        return;
+    }
+
+    // ✅ Check if the target player is vanished
+    if (target.hasMetadata("vanished")) {
+        return;
+    }
+
+    // Only show menu if the player is sneaking and online
+    if (!event.isSneaking()) {
+        return;
+    }
+
+    if (Bukkit.getServer().getOnlinePlayers().contains(p)) {
+        Display.spawnMenu(p, target);
+    }
 }
+

--- a/src/main/java/me/yirf/judge/events/OnSneak.java
+++ b/src/main/java/me/yirf/judge/events/OnSneak.java
@@ -18,27 +18,23 @@ import static me.yirf.judge.group.Group.group;
 public void onShift(PlayerToggleSneakEvent event) {
     Player p = event.getPlayer();
 
-    // If the player is already in a group, remove them
     if (group.get(p.getUniqueId()) != null) {
         Group.remove(p);
         return;
     }
 
-    // World restriction check
     if (!Config.getBoolean("allow-all-worlds")) {
         if (!Judge.allowedWorlds.contains(p.getWorld())) {
             return;
         }
     }
 
-    // WorldGuard region check
     if (Judge.hasWorldGuard && Config.getBoolean("specific-regions")) {
         if (!RegionUtil.containsRegion(p, Config.getStringList("allowed-regions"))) {
             return;
         }
     }
 
-    // Ray trace for nearby player
     RayTraceResult result = p.rayTraceEntities(10);
     if (result == null || !(result.getHitEntity() instanceof Player)) {
         return;
@@ -46,17 +42,14 @@ public void onShift(PlayerToggleSneakEvent event) {
 
     Player target = (Player) result.getHitEntity();
 
-    // Check if target is an NPC
     if (target.hasMetadata("NPC")) {
         return;
     }
 
-    // ✅ Check if the target player is vanished
     if (target.hasMetadata("vanished")) {
         return;
     }
 
-    // Only show menu if the player is sneaking and online
     if (!event.isSneaking()) {
         return;
     }

--- a/src/main/java/me/yirf/judge/events/OnSneakDelay.java
+++ b/src/main/java/me/yirf/judge/events/OnSneakDelay.java
@@ -12,6 +12,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.util.RayTraceResult;
+
 import static me.yirf.judge.group.Group.group;
 import static me.yirf.judge.group.Group.control;
 
@@ -20,7 +21,9 @@ public class OnSneakDelay implements Listener {
     public void onShift(PlayerToggleSneakEvent event) {
         Player p = event.getPlayer();
 
-        if(control.get(p.getUniqueId()) != null) {;return;}
+        if (control.get(p.getUniqueId()) != null) {
+            return;
+        }
 
         if (group.get(p.getUniqueId()) != null) {
             Group.remove(p);
@@ -28,39 +31,49 @@ public class OnSneakDelay implements Listener {
             return;
         }
 
-        if(!Config.getBoolean("allow-all-worlds")) {
+        if (!Config.getBoolean("allow-all-worlds")) {
             if (!Judge.allowedWorlds.contains(p.getWorld())) {
                 return;
             }
         }
 
         if (Judge.hasWorldGuard || Config.getBoolean("specific-regions")) {
-            if (!RegionUtil.containsRegion
-                    (p, Config.getStringList("allowed-regions")
-                    )) return;
+            if (!RegionUtil.containsRegion(p, Config.getStringList("allowed-regions"))) {
+                return;
+            }
         }
 
-        if (!event.isSneaking()) {return;}
+        if (!event.isSneaking()) {
+            return;
+        }
 
-        Bukkit.getScheduler().runTaskLater(Judge.instance, () -> { //super fat fucking sched!!!
+        Bukkit.getScheduler().runTaskLater(Judge.instance, () -> {
             control.put(p.getUniqueId(), true);
+
             RayTraceResult result = p.rayTraceEntities(10);
             if (result == null || !(result.getHitEntity() instanceof Player)) {
                 return;
             }
-            Entity entity = result.getHitEntity();
-            if (entity.hasMetadata("NPC")) {
+
+            Player target = (Player) result.getHitEntity();
+
+            if (target.hasMetadata("NPC")) {
                 return;
             }
-            if(!Bukkit.getServer().getOnlinePlayers().contains((Player) entity)) {
+
+            if (target.hasMetadata("vanished")) {
                 return;
             }
-            if (!event.isSneaking()) {
+
+            if (!Bukkit.getServer().getOnlinePlayers().contains(target)) {
                 return;
             }
-            Display.spawnMenu(p, (Player) entity);
+
+            if (!p.isSneaking()) {
+                return;
+            }
+
+            Display.spawnMenu(p, target);
         }, Config.getInt("delay"));
-
     }
-
 }


### PR DESCRIPTION
My previous issue #7 was marked as completed but after further testing the implementation didn't work; ie. testing with PremiumVanish & EssentialsVanish on latest

I implemented proper Vanish plugin support with this commit; by checking the standard of the vanished metadata (which most decent vanish plugins use) of the player, and hiding it if they're vanished.

This also is a basic code cleanup of the events via autoStitch